### PR TITLE
perf: Fibonacci-hashed order-id index

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -181,6 +181,83 @@ func runBenchmarkThroughput(b *testing.B, duration time.Duration, lowerBound, up
 	return throughput, avgLatency
 }
 
+// deepWindow is the number of live resting orders maintained by the deep-book
+// benchmarks (analog of the C++ -depth 50000 workload).
+const deepWindow = 50000
+
+// BenchmarkThroughputDeep measures add/cancel throughput while maintaining a
+// sliding window of ~deepWindow live resting orders with monotonically climbing
+// ids. Each iteration adds one non-crossing resting order (price spread across
+// the band) and, once the live count exceeds the window, cancels the oldest
+// still-live id. This exercises the order-id index at a realistic depth.
+func BenchmarkThroughputDeep(b *testing.B) {
+	b.ResetTimer()
+	throughput, avgLatency := runBenchmarkThroughputDeep(b, duration, lowerBound, upperBound, minSpread)
+	b.StopTimer()
+
+	b.ReportMetric(throughput, "ops/sec")
+	b.ReportMetric(avgLatency, "ns/op")
+}
+
+func runBenchmarkThroughputDeep(b *testing.B, duration time.Duration, lowerBound, upperBound, minSpread decimal.Decimal) (float64, float64) {
+	ob := getOrderBook()
+
+	// Split the band around the mid so buys rest below and sells rest above,
+	// guaranteeing resting (non-crossing) orders. Prices are spread across the
+	// band by stepping minSpread within each half.
+	mid := lowerBound.Add(upperBound).Div(decimal.NewI(2, 0))
+	qty := decimal.NewI(10, 0)
+	bandSteps := int64(upperBound.Sub(lowerBound).Div(minSpread).Float() / 2)
+	if bandSteps < 1 {
+		bandSteps = 1
+	}
+
+	priceFor := func(i uint64) (decimal.Decimal, SideType) {
+		step := decimal.NewI((i%uint64(bandSteps))+1, 0).Mul(minSpread)
+		if i&1 == 0 {
+			// Buy resting below mid.
+			return mid.Sub(step), Buy
+		}
+		// Sell resting above mid.
+		return mid.Add(step), Sell
+	}
+
+	b.ReportAllocs()
+
+	var tok, id uint64
+	// oldest is the smallest id still potentially live; cancel walks forward.
+	var oldest uint64 = 1
+
+	// Pre-fill the window so we measure steady-state add+cancel.
+	for live := 0; live < deepWindow; live++ {
+		id++
+		tok++
+		price, side := priceFor(id)
+		ob.AddOrder(tok, id, Limit, side, qty, price, decimal.Zero, None)
+	}
+
+	iterations := uint64(duration.Seconds()) * 2_000_000
+
+	start := hrtime.TSC()
+	for i := uint64(0); i < iterations; i++ {
+		id++
+		tok++
+		price, side := priceFor(id)
+		ob.AddOrder(tok, id, Limit, side, qty, price, decimal.Zero, None)
+
+		tok++
+		ob.CancelOrder(tok, oldest)
+		oldest++
+	}
+
+	operations := iterations * 2
+	elapsed := hrtime.TSCSince(start).ApproxDuration()
+	throughput := float64(operations) / elapsed.Seconds()
+	avgLatency := float64(elapsed.Nanoseconds()) / float64(operations)
+
+	return throughput, avgLatency
+}
+
 func printResultsWithPercentiles(b *testing.B, operationName string, hist *stats.Histogram) {
 	percentiles := []float64{50, 75, 90, 95, 99, 99.9, 99.99, 99.9999, 100}
 	b.Logf("Operation: %s", operationName)

--- a/orderbook.go
+++ b/orderbook.go
@@ -4,7 +4,6 @@ import (
 	"sync/atomic"
 
 	"github.com/geseq/orderbook/pkg/pool"
-	local_tree "github.com/geseq/orderbook/pkg/tree"
 	decimal "github.com/geseq/udecimal"
 )
 
@@ -23,8 +22,8 @@ type OrderBook struct {
 	bids         *priceLevel
 	triggerUnder *priceLevel                      // orders triggering under last price i.e. Stop Sell or Take Buy
 	triggerOver  *priceLevel                      // orders that trigger over last price i.e. Stop Buy or Take Sell
-	orders       *local_tree.Tree[uint64, *Order] // orderId -> *Order
-	trigOrders   *local_tree.Tree[uint64, *Order] // orderId -> *Order
+	orders       *orderIndex // orderId -> *Order
+	trigOrders   *orderIndex // orderId -> *Order
 	trigQueue    *triggerQueue
 
 	notification NotificationHandler
@@ -54,8 +53,6 @@ func Uint64Cmp(a, b uint64) int {
 // NewOrderBook creates Orderbook object
 func NewOrderBook(n NotificationHandler, opts ...Option) *OrderBook {
 	ob := &OrderBook{
-		orders:       local_tree.NewWithTree[uint64, *Order](Uint64Cmp, 2),
-		trigOrders:   local_tree.NewWithTree[uint64, *Order](Uint64Cmp, 2),
 		trigQueue:    newTriggerQueue(),
 		bids:         newPriceLevel(BidPrice),
 		asks:         newPriceLevel(AskPrice),
@@ -66,6 +63,9 @@ func NewOrderBook(n NotificationHandler, opts ...Option) *OrderBook {
 
 	options(defaultOpts).applyTo(ob)
 	options(opts).applyTo(ob)
+
+	ob.orders = newOrderIndex(ob.orderPoolSize)
+	ob.trigOrders = newOrderIndex(2)
 
 	oPool = pool.NewItemPoolV2[Order](ob.orderPoolSize)
 	oqPool = pool.NewItemPoolV2[orderQueue](ob.orderQueuePoolSize)
@@ -130,7 +130,7 @@ func (ob *OrderBook) AddOrder(tok, id uint64, class ClassType, side SideType, qu
 	}
 
 	if class != Market {
-		if _, ok := ob.orders.Get(id); ok {
+		if _, ok := ob.orders.get(id); ok {
 			ob.notification.PutOrder(MsgCreateOrder, Rejected, id, decimal.Zero, ErrOrderExists)
 			return
 		}
@@ -158,7 +158,7 @@ func (ob *OrderBook) addTrigOrder(id uint64, class ClassType, side SideType, qua
 				return
 			}
 
-			ob.trigOrders.Put(id, ob.triggerOver.Append(NewOrder(id, class, side, quantity, price, stPrice, flag)))
+			ob.trigOrders.put(id, ob.triggerOver.Append(NewOrder(id, class, side, quantity, price, stPrice, flag)))
 		case Sell:
 			if ob.lastPrice.LessThanOrEqual(stPrice) {
 				// Stop sell set over stop price, condition satisfied to trigger
@@ -166,7 +166,7 @@ func (ob *OrderBook) addTrigOrder(id uint64, class ClassType, side SideType, qua
 				return
 			}
 
-			ob.trigOrders.Put(id, ob.triggerUnder.Append(NewOrder(id, class, side, quantity, price, stPrice, flag)))
+			ob.trigOrders.put(id, ob.triggerUnder.Append(NewOrder(id, class, side, quantity, price, stPrice, flag)))
 		}
 	case TakeProfit:
 		switch side {
@@ -177,7 +177,7 @@ func (ob *OrderBook) addTrigOrder(id uint64, class ClassType, side SideType, qua
 				return
 			}
 
-			ob.trigOrders.Put(id, ob.triggerUnder.Append(NewOrder(id, class, side, quantity, price, stPrice, flag)))
+			ob.trigOrders.put(id, ob.triggerUnder.Append(NewOrder(id, class, side, quantity, price, stPrice, flag)))
 		case Sell:
 			if stPrice.LessThanOrEqual(ob.lastPrice) {
 				// Stop sell set over stop price, condition satisfied to trigger
@@ -185,7 +185,7 @@ func (ob *OrderBook) addTrigOrder(id uint64, class ClassType, side SideType, qua
 				return
 			}
 
-			ob.trigOrders.Put(id, ob.triggerOver.Append(NewOrder(id, class, side, quantity, price, stPrice, flag)))
+			ob.trigOrders.put(id, ob.triggerOver.Append(NewOrder(id, class, side, quantity, price, stPrice, flag)))
 		}
 	}
 }
@@ -228,9 +228,9 @@ func (ob *OrderBook) processOrder(id uint64, class ClassType, side SideType, qua
 	if quantityLeft.GreaterThan(decimal.Zero) {
 		o := NewOrder(id, class, side, quantityLeft, price, decimal.Zero, flag)
 		if side == Buy {
-			ob.orders.Put(id, ob.bids.Append(o))
+			ob.orders.put(id, ob.bids.Append(o))
 		} else {
-			ob.orders.Put(id, ob.asks.Append(o))
+			ob.orders.put(id, ob.asks.Append(o))
 		}
 	}
 
@@ -270,9 +270,9 @@ func (ob *OrderBook) processTriggeredOrders() {
 
 // Order returns order by id
 func (ob *OrderBook) Order(orderID uint64) *Order {
-	o, ok := ob.orders.Get(orderID)
+	o, ok := ob.orders.get(orderID)
 	if !ok {
-		o, ok := ob.trigOrders.Get(orderID)
+		o, ok := ob.trigOrders.get(orderID)
 		if !ok {
 			return nil
 		}
@@ -301,12 +301,12 @@ func (ob *OrderBook) CancelOrder(tok, orderID uint64) {
 
 // CancelOrder removes order with given ID from the order book
 func (ob *OrderBook) cancelOrder(orderID uint64) *Order {
-	o, ok := ob.orders.Get(orderID)
+	o, ok := ob.orders.get(orderID)
 	if !ok {
 		return ob.cancelTrigOrders(orderID)
 	}
 
-	ob.orders.Remove(orderID)
+	ob.orders.remove(orderID)
 
 	if o.Side == Buy {
 		return ob.bids.Remove(o)
@@ -316,12 +316,12 @@ func (ob *OrderBook) cancelOrder(orderID uint64) *Order {
 }
 
 func (ob *OrderBook) cancelTrigOrders(orderID uint64) *Order {
-	o, ok := ob.trigOrders.Get(orderID)
+	o, ok := ob.trigOrders.get(orderID)
 	if !ok {
 		return nil
 	}
 
-	ob.trigOrders.Remove(orderID)
+	ob.trigOrders.remove(orderID)
 
 	if (o.Flag & StopLoss) != 0 {
 		if o.Side == Buy {

--- a/orderindex.go
+++ b/orderindex.go
@@ -1,0 +1,135 @@
+package orderbook
+
+import "math/bits"
+
+// fibHash is the 64-bit Fibonacci hashing multiplier (2^64 / golden ratio).
+const fibHash = 0x9E3779B97F4A7C15
+
+// orderIndexNode is a chained bucket entry mapping an order id to its *Order.
+type orderIndexNode struct {
+	key  uint64
+	val  *Order
+	next *orderIndexNode
+}
+
+// orderIndex is a chained hash map specialized for uint64 -> *Order keyed by
+// order id. It uses Fibonacci (multiplicative) hashing to avoid modulo, and a
+// node free-list to recycle removed nodes and avoid GC churn. This is the Go
+// port of the C++ Fibonacci-hashed pooled-node map.
+type orderIndex struct {
+	buckets []*orderIndexNode
+	mask    uint64
+	shift   uint
+	count   int
+	free    *orderIndexNode
+}
+
+// nextPow2 rounds n up to the next power of two (minimum 1).
+func nextPow2(n uint64) uint64 {
+	if n < 2 {
+		return 1
+	}
+	return uint64(1) << uint(bits.Len64(n-1))
+}
+
+// newOrderIndex creates an orderIndex sized to hold roughly hint entries before
+// the first grow. The bucket count is a power of two.
+func newOrderIndex(hint uint64) *orderIndex {
+	// Size buckets so that hint entries stay under the 0.7 load factor.
+	n := nextPow2(hint)
+	if n < 2 {
+		n = 2
+	}
+	oi := &orderIndex{}
+	oi.setBuckets(make([]*orderIndexNode, n))
+	return oi
+}
+
+func (oi *orderIndex) setBuckets(b []*orderIndexNode) {
+	oi.buckets = b
+	oi.mask = uint64(len(b) - 1)
+	oi.shift = uint(64 - bits.TrailingZeros64(uint64(len(b))))
+}
+
+func (oi *orderIndex) index(key uint64) uint64 {
+	return (key * fibHash) >> oi.shift
+}
+
+// get returns the *Order for key and whether it was present.
+func (oi *orderIndex) get(key uint64) (*Order, bool) {
+	for n := oi.buckets[oi.index(key)]; n != nil; n = n.next {
+		if n.key == key {
+			return n.val, true
+		}
+	}
+	return nil, false
+}
+
+// put inserts or updates the value for key. It is safe to call for an existing
+// key (the value is overwritten without inserting a duplicate node).
+func (oi *orderIndex) put(key uint64, val *Order) {
+	idx := oi.index(key)
+	for n := oi.buckets[idx]; n != nil; n = n.next {
+		if n.key == key {
+			n.val = val
+			return
+		}
+	}
+
+	n := oi.free
+	if n != nil {
+		oi.free = n.next
+	} else {
+		n = &orderIndexNode{}
+	}
+	n.key = key
+	n.val = val
+	n.next = oi.buckets[idx]
+	oi.buckets[idx] = n
+	oi.count++
+
+	// Grow at load factor ~0.7.
+	if uint64(oi.count)*10 >= uint64(len(oi.buckets))*7 {
+		oi.grow()
+	}
+}
+
+// remove unlinks key from its bucket chain, recycles the node onto the
+// free-list, and returns the removed value and whether it was present.
+func (oi *orderIndex) remove(key uint64) (*Order, bool) {
+	idx := oi.index(key)
+	prev := (*orderIndexNode)(nil)
+	for n := oi.buckets[idx]; n != nil; n = n.next {
+		if n.key == key {
+			if prev == nil {
+				oi.buckets[idx] = n.next
+			} else {
+				prev.next = n.next
+			}
+			val := n.val
+			n.val = nil
+			n.next = oi.free
+			oi.free = n
+			oi.count--
+			return val, true
+		}
+		prev = n
+	}
+	return nil, false
+}
+
+// grow doubles the bucket count and rehashes the existing nodes in place,
+// reusing the node objects (no allocation per entry).
+func (oi *orderIndex) grow() {
+	old := oi.buckets
+	oi.setBuckets(make([]*orderIndexNode, len(old)*2))
+	for _, n := range old {
+		for n != nil {
+			next := n.next
+			idx := oi.index(n.key)
+			n.next = oi.buckets[idx]
+			oi.buckets[idx] = n
+			n = next
+		}
+	}
+}

--- a/orderindex_test.go
+++ b/orderindex_test.go
@@ -1,0 +1,112 @@
+package orderbook
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestNextPow2(t *testing.T) {
+	cases := map[uint64]uint64{
+		0: 1, 1: 1, 2: 2, 3: 4, 4: 4, 5: 8, 7: 8, 8: 8, 9: 16, 1000: 1024, 1024: 1024, 1025: 2048,
+	}
+	for in, want := range cases {
+		if got := nextPow2(in); got != want {
+			t.Fatalf("nextPow2(%d) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+// TestOrderIndexAgainstOracle fuzzes the orderIndex against a builtin map oracle
+// over random uint64 keys with insert/get/remove churn that forces growth and
+// exercises the free-list reuse path.
+func TestOrderIndexAgainstOracle(t *testing.T) {
+	rng := rand.New(rand.NewSource(12345))
+
+	for trial := 0; trial < 20; trial++ {
+		oi := newOrderIndex(4)
+		oracle := make(map[uint64]*Order)
+
+		for op := 0; op < 20000; op++ {
+			// Bias key space small enough to force collisions and churn,
+			// but include occasional huge keys to stress the hash spread.
+			var key uint64
+			switch rng.Intn(4) {
+			case 0:
+				key = uint64(rng.Intn(64))
+			case 1:
+				key = uint64(rng.Intn(4096))
+			default:
+				key = rng.Uint64()
+			}
+
+			switch rng.Intn(3) {
+			case 0: // put
+				o := &Order{ID: key}
+				oi.put(key, o)
+				oracle[key] = o
+			case 1: // get
+				gotVal, gotOK := oi.get(key)
+				wantVal, wantOK := oracle[key]
+				if gotOK != wantOK || gotVal != wantVal {
+					t.Fatalf("get(%d) = (%v,%v), want (%v,%v)", key, gotVal, gotOK, wantVal, wantOK)
+				}
+			case 2: // remove
+				gotVal, gotOK := oi.remove(key)
+				wantVal, wantOK := oracle[key]
+				if gotOK != wantOK || gotVal != wantVal {
+					t.Fatalf("remove(%d) = (%v,%v), want (%v,%v)", key, gotVal, gotOK, wantVal, wantOK)
+				}
+				delete(oracle, key)
+			}
+
+			if oi.count != len(oracle) {
+				t.Fatalf("count mismatch: oi.count=%d oracle=%d", oi.count, len(oracle))
+			}
+		}
+
+		// Full sweep: every oracle key must be present with matching value.
+		for k, v := range oracle {
+			got, ok := oi.get(k)
+			if !ok || got != v {
+				t.Fatalf("final get(%d) = (%v,%v), want (%v,true)", k, got, ok, v)
+			}
+		}
+		// Keys absent from the oracle must be absent from the index.
+		for probe := 0; probe < 200; probe++ {
+			k := uint64(rng.Intn(8192))
+			_, want := oracle[k]
+			_, got := oi.get(k)
+			if got != want {
+				t.Fatalf("presence mismatch for %d: oi=%v oracle=%v", k, got, want)
+			}
+		}
+	}
+}
+
+// TestOrderIndexFreeListReuse verifies that removed nodes are recycled from the
+// free-list on subsequent puts (no unbounded allocation under add/remove churn).
+func TestOrderIndexFreeListReuse(t *testing.T) {
+	oi := newOrderIndex(4)
+	o := &Order{ID: 1}
+
+	oi.put(1, o)
+	if oi.free != nil {
+		t.Fatalf("free-list should be empty after first put")
+	}
+	oi.remove(1)
+	if oi.free == nil {
+		t.Fatalf("free-list should hold the recycled node after remove")
+	}
+	recycled := oi.free
+	oi.put(2, o)
+	if oi.free != nil {
+		t.Fatalf("free-list should be empty after reusing the recycled node")
+	}
+	if got, _ := oi.get(2); got != o {
+		t.Fatalf("get(2) after reuse returned wrong value")
+	}
+	// The node reused for key 2 should be the previously freed node.
+	if oi.buckets[oi.index(2)] != recycled {
+		t.Fatalf("put did not reuse the recycled node from the free-list")
+	}
+}


### PR DESCRIPTION
Replaces the order-id index red-black tree (`orders`/`trigOrders`) with a custom Fibonacci-hashed chained map (`orderindex.go`): power-of-2 buckets, multiplicative hash (no modulo), and a node free-list so steady-state add/cancel does no allocation.

The tree was O(log N) with pointer-chasing per Get/Put/Remove; the map is O(1) and flat across book depth. Adds `BenchmarkThroughputDeep` (sliding window of N live resting orders) to measure realistic depths.

Throughput by book depth (12th Gen i7, best-of-3):

| Live orders | tree | this PR | 
|---|---|---|
| ~2 (existing microbench) | ~18M | ~15M |
| 1,000 | 7.1M | 23.6M |
| 5,000 | 5.8M | 20.7M |
| 50,000 | 5.2M | 19.3M |

Tree only wins the degenerate ~2-live microbench; at any realistic depth this is ~3-4x faster (and flat O(1) vs the tree's O(log N) decay). `go test ./...` green, including a fuzz test of the index vs a builtin-map oracle (random keys, churn, grow/rehash, free-list reuse).